### PR TITLE
Fix critical bugs and code quality issues

### DIFF
--- a/Mister.Version.Core/Services/GitService.cs
+++ b/Mister.Version.Core/Services/GitService.cs
@@ -248,8 +248,6 @@ namespace Mister.Version.Core.Services
                 $"{projectName}-{tagPrefix}",
                 $"{projectName}/{tagPrefix}",
                 $"{projectName.ToLowerInvariant()}/{tagPrefix}",
-                // Additional formats for compatibility
-                $"{projectName.ToLowerInvariant().Replace(".", ".")}/{tagPrefix}",
             };
 
             // Note: We don't support suffix format (v1.2.3-projectname) as it conflicts with feature branch tags
@@ -364,11 +362,7 @@ namespace Mister.Version.Core.Services
                     foreach (var dependency in dependencies)
                     {
 #if NET472
-#if NET472
                         var relativeDependencyPath = NormalizePath(Mister.Version.Core.PathUtils.GetRelativePath(repoRoot, dependency));
-#else
-                        var relativeDependencyPath = NormalizePath(Path.GetRelativePath(repoRoot, dependency));
-#endif
 #else
                         var relativeDependencyPath = NormalizePath(Path.GetRelativePath(repoRoot, dependency));
 #endif

--- a/Mister.Version.Core/Services/ProjectAnalyzer.cs
+++ b/Mister.Version.Core/Services/ProjectAnalyzer.cs
@@ -115,7 +115,7 @@ namespace Mister.Version.Core.Services
                 Dependencies = transitiveDependencies,
                 IsTestProject = isTestProject,
                 IsPackable = isPackable,
-                BaseVersion = additionalOptions.BaseVersion
+                BaseVersion = additionalOptions?.BaseVersion
             };
 
             // Apply additional options if provided
@@ -125,7 +125,7 @@ namespace Mister.Version.Core.Services
                 versionOptions.Debug = additionalOptions.Debug;
                 versionOptions.TagPrefix = additionalOptions.TagPrefix;
                 versionOptions.ForceVersion = additionalOptions.ForceVersion;
-                
+
                 // Override dependencies if provided in additional options
                 if (additionalOptions.Dependencies != null && additionalOptions.Dependencies.Count > 0)
                 {

--- a/Mister.Version.Core/Services/VersionCache.cs
+++ b/Mister.Version.Core/Services/VersionCache.cs
@@ -290,7 +290,11 @@ namespace Mister.Version.Core.Services
 
         public override string ToString()
         {
-            return $"VersionCache Statistics: HEAD={CurrentHeadSha?.Substring(0, 8)}, " +
+            var headShaDisplay = string.IsNullOrEmpty(CurrentHeadSha)
+                ? "null"
+                : (CurrentHeadSha.Length >= 8 ? CurrentHeadSha.Substring(0, 8) : CurrentHeadSha);
+
+            return $"VersionCache Statistics: HEAD={headShaDisplay}, " +
                    $"AllProjects={AllProjectsCached}, " +
                    $"ProjectDeps={ProjectDependenciesCount}, " +
                    $"GlobalTags={GlobalVersionTagsCached}, " +


### PR DESCRIPTION
Priority fixes based on code review:

1. Fix duplicate nested preprocessor directive in GitService.cs
   - Removed nested #if NET472 that prevented correct compilation
   - Now properly handles .NET Framework 4.7.2 path resolution

2. Fix potential NullReferenceException in ProjectAnalyzer.cs
   - Changed BaseVersion assignment to use null-conditional operator
   - Prevents crash when additionalOptions is null

3. Remove useless Replace operation in GitService.cs
   - Removed redundant Replace(".", ".") call that did nothing
   - Cleaned up dead code in tag prefix generation

4. Add null safety to CacheStatistics.ToString()
   - Added proper null and length checks for CurrentHeadSha
   - Prevents StringIndexOutOfBoundsException when SHA is null or short

These fixes improve code correctness, prevent potential crashes, and maintain compatibility with both .NET Framework and .NET Core/5+.