### PR TITLE
feat: Add automatic changelog generation from commit history

### DIFF
--- a/Mister.Version.Core/Models/Changelog.cs
+++ b/Mister.Version.Core/Models/Changelog.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mister.Version.Core.Models
+{
+    /// <summary>
+    /// Represents a complete changelog for a version
+    /// </summary>
+    public class Changelog
+    {
+        /// <summary>
+        /// Version this changelog is for
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Previous version
+        /// </summary>
+        public string PreviousVersion { get; set; }
+
+        /// <summary>
+        /// Date the version was released
+        /// </summary>
+        public DateTimeOffset Date { get; set; }
+
+        /// <summary>
+        /// Project name (for monorepo scenarios)
+        /// </summary>
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// Sections in this changelog
+        /// </summary>
+        public List<ChangelogSection> Sections { get; set; } = new List<ChangelogSection>();
+
+        /// <summary>
+        /// Total number of commits in this changelog
+        /// </summary>
+        public int TotalCommits { get; set; }
+
+        /// <summary>
+        /// Number of contributors
+        /// </summary>
+        public int ContributorCount { get; set; }
+
+        /// <summary>
+        /// List of contributors
+        /// </summary>
+        public List<string> Contributors { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Version bump type
+        /// </summary>
+        public VersionBumpType BumpType { get; set; }
+    }
+}

--- a/Mister.Version.Core/Models/ChangelogConfig.cs
+++ b/Mister.Version.Core/Models/ChangelogConfig.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+
+namespace Mister.Version.Core.Models
+{
+    /// <summary>
+    /// Configuration for changelog generation
+    /// </summary>
+    public class ChangelogConfig
+    {
+        /// <summary>
+        /// Whether changelog generation is enabled
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Output format (markdown, json, text)
+        /// </summary>
+        public string OutputFormat { get; set; } = "markdown";
+
+        /// <summary>
+        /// Path to write changelog file
+        /// </summary>
+        public string OutputPath { get; set; } = "CHANGELOG.md";
+
+        /// <summary>
+        /// Whether to include commit links
+        /// </summary>
+        public bool IncludeCommitLinks { get; set; } = true;
+
+        /// <summary>
+        /// Whether to include issue references
+        /// </summary>
+        public bool IncludeIssueReferences { get; set; } = true;
+
+        /// <summary>
+        /// Whether to include PR references
+        /// </summary>
+        public bool IncludePullRequestReferences { get; set; } = true;
+
+        /// <summary>
+        /// Whether to include commit authors
+        /// </summary>
+        public bool IncludeAuthors { get; set; } = false;
+
+        /// <summary>
+        /// Whether to include commit dates
+        /// </summary>
+        public bool IncludeDates { get; set; } = true;
+
+        /// <summary>
+        /// Repository URL for generating links (e.g., https://github.com/owner/repo)
+        /// </summary>
+        public string RepositoryUrl { get; set; }
+
+        /// <summary>
+        /// Custom sections configuration
+        /// </summary>
+        public List<ChangelogSectionConfig> Sections { get; set; } = new List<ChangelogSectionConfig>
+        {
+            new ChangelogSectionConfig
+            {
+                Title = "Breaking Changes",
+                Emoji = "💥",
+                CommitTypes = new List<string> { "breaking" },
+                Order = 1
+            },
+            new ChangelogSectionConfig
+            {
+                Title = "Features",
+                Emoji = "🚀",
+                CommitTypes = new List<string> { "feat", "feature" },
+                Order = 2
+            },
+            new ChangelogSectionConfig
+            {
+                Title = "Bug Fixes",
+                Emoji = "🐛",
+                CommitTypes = new List<string> { "fix", "bugfix" },
+                Order = 3
+            },
+            new ChangelogSectionConfig
+            {
+                Title = "Performance",
+                Emoji = "⚡",
+                CommitTypes = new List<string> { "perf" },
+                Order = 4
+            },
+            new ChangelogSectionConfig
+            {
+                Title = "Refactoring",
+                Emoji = "♻️",
+                CommitTypes = new List<string> { "refactor" },
+                Order = 5
+            },
+            new ChangelogSectionConfig
+            {
+                Title = "Documentation",
+                Emoji = "📝",
+                CommitTypes = new List<string> { "docs" },
+                Order = 6
+            }
+        };
+
+        /// <summary>
+        /// Whether to group breaking changes separately
+        /// </summary>
+        public bool GroupBreakingChanges { get; set; } = true;
+
+        /// <summary>
+        /// Whether to include scopes in output
+        /// </summary>
+        public bool IncludeScopes { get; set; } = true;
+
+        /// <summary>
+        /// Maximum number of entries per section (0 = unlimited)
+        /// </summary>
+        public int MaxEntriesPerSection { get; set; } = 0;
+    }
+
+    /// <summary>
+    /// Configuration for a changelog section
+    /// </summary>
+    public class ChangelogSectionConfig
+    {
+        /// <summary>
+        /// Section title
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Section emoji/icon
+        /// </summary>
+        public string Emoji { get; set; }
+
+        /// <summary>
+        /// Commit types that belong to this section
+        /// </summary>
+        public List<string> CommitTypes { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Display order
+        /// </summary>
+        public int Order { get; set; }
+
+        /// <summary>
+        /// Whether to show this section even if empty
+        /// </summary>
+        public bool ShowIfEmpty { get; set; }
+    }
+}

--- a/Mister.Version.Core/Models/ChangelogEntry.cs
+++ b/Mister.Version.Core/Models/ChangelogEntry.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Mister.Version.Core.Models
+{
+    /// <summary>
+    /// Represents a single entry in a changelog
+    /// </summary>
+    public class ChangelogEntry
+    {
+        /// <summary>
+        /// Commit SHA
+        /// </summary>
+        public string CommitSha { get; set; }
+
+        /// <summary>
+        /// Commit type (feat, fix, etc.)
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Scope of the change (optional)
+        /// </summary>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Description of the change
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Full commit message
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Whether this is a breaking change
+        /// </summary>
+        public bool IsBreakingChange { get; set; }
+
+        /// <summary>
+        /// Breaking change description (if applicable)
+        /// </summary>
+        public string BreakingChangeDescription { get; set; }
+
+        /// <summary>
+        /// Commit author
+        /// </summary>
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Commit date
+        /// </summary>
+        public DateTimeOffset Date { get; set; }
+
+        /// <summary>
+        /// GitHub issue numbers referenced in the commit
+        /// </summary>
+        public string[] IssueReferences { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// GitHub PR number (if available)
+        /// </summary>
+        public string PullRequestNumber { get; set; }
+
+        /// <summary>
+        /// Version bump type for this entry
+        /// </summary>
+        public VersionBumpType BumpType { get; set; }
+    }
+}

--- a/Mister.Version.Core/Models/ChangelogSection.cs
+++ b/Mister.Version.Core/Models/ChangelogSection.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace Mister.Version.Core.Models
+{
+    /// <summary>
+    /// Represents a section in a changelog (e.g., Breaking Changes, Features, Bug Fixes)
+    /// </summary>
+    public class ChangelogSection
+    {
+        /// <summary>
+        /// Section title
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Section emoji/icon (optional)
+        /// </summary>
+        public string Emoji { get; set; }
+
+        /// <summary>
+        /// Commit types that belong to this section
+        /// </summary>
+        public List<string> CommitTypes { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Entries in this section
+        /// </summary>
+        public List<ChangelogEntry> Entries { get; set; } = new List<ChangelogEntry>();
+
+        /// <summary>
+        /// Display order (lower numbers first)
+        /// </summary>
+        public int Order { get; set; }
+
+        /// <summary>
+        /// Whether to show this section even if empty
+        /// </summary>
+        public bool ShowIfEmpty { get; set; }
+    }
+}

--- a/Mister.Version.Core/Models/VersionConfig.cs
+++ b/Mister.Version.Core/Models/VersionConfig.cs
@@ -45,6 +45,11 @@ public class VersionConfig
     /// Conventional commits configuration for semantic version bump detection
     /// </summary>
     public ConventionalCommitConfig CommitConventions { get; set; }
+
+    /// <summary>
+    /// Changelog generation configuration
+    /// </summary>
+    public ChangelogConfig Changelog { get; set; }
 }
 
 /// <summary>

--- a/Mister.Version.Core/Services/ChangelogGenerator.cs
+++ b/Mister.Version.Core/Services/ChangelogGenerator.cs
@@ -1,0 +1,435 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using LibGit2Sharp;
+using Mister.Version.Core.Models;
+
+namespace Mister.Version.Core.Services
+{
+    /// <summary>
+    /// Service for generating changelogs from commit history
+    /// </summary>
+    public class ChangelogGenerator : IChangelogGenerator
+    {
+        private readonly ICommitAnalyzer _commitAnalyzer;
+
+        // Regex patterns for extracting references
+        private static readonly Regex IssueReferencePattern = new Regex(
+            @"#(\d+)",
+            RegexOptions.Compiled);
+
+        private static readonly Regex PullRequestPattern = new Regex(
+            @"\(#(\d+)\)\s*$",
+            RegexOptions.Compiled);
+
+        public ChangelogGenerator(ICommitAnalyzer commitAnalyzer)
+        {
+            _commitAnalyzer = commitAnalyzer ?? new ConventionalCommitAnalyzer();
+        }
+
+        public Changelog GenerateChangelog(
+            IEnumerable<Commit> commits,
+            string version,
+            string previousVersion,
+            ChangelogConfig config,
+            ConventionalCommitConfig conventionalCommitConfig,
+            string projectName = null)
+        {
+            var commitList = commits?.ToList() ?? new List<Commit>();
+
+            var changelog = new Changelog
+            {
+                Version = version,
+                PreviousVersion = previousVersion,
+                Date = DateTimeOffset.Now,
+                ProjectName = projectName,
+                TotalCommits = commitList.Count
+            };
+
+            // Analyze and classify all commits
+            var entries = new List<ChangelogEntry>();
+            var contributors = new HashSet<string>();
+
+            foreach (var commit in commitList)
+            {
+                var classification = _commitAnalyzer.ClassifyCommit(commit, conventionalCommitConfig);
+
+                // Skip ignored commits
+                if (classification.ShouldIgnore)
+                    continue;
+
+                var entry = CreateChangelogEntry(commit, classification, config);
+                entries.Add(entry);
+
+                if (!string.IsNullOrEmpty(commit.Author?.Name))
+                    contributors.Add(commit.Author.Name);
+            }
+
+            // Determine overall bump type
+            changelog.BumpType = entries.Any()
+                ? entries.Max(e => e.BumpType)
+                : VersionBumpType.None;
+
+            // Group entries into sections
+            changelog.Sections = GroupEntriesIntoSections(entries, config);
+
+            // Set contributor information
+            changelog.Contributors = contributors.OrderBy(c => c).ToList();
+            changelog.ContributorCount = contributors.Count;
+
+            return changelog;
+        }
+
+        private ChangelogEntry CreateChangelogEntry(Commit commit, CommitClassification classification, ChangelogConfig config)
+        {
+            var entry = new ChangelogEntry
+            {
+                CommitSha = commit.Sha?.Substring(0, Math.Min(7, commit.Sha.Length)),
+                Type = classification.CommitType,
+                Scope = classification.Scope,
+                Description = classification.Description,
+                Message = commit.Message,
+                IsBreakingChange = classification.IsBreakingChange,
+                BreakingChangeDescription = classification.BreakingChangeDescription,
+                Author = commit.Author?.Name,
+                Date = commit.Author?.When ?? DateTimeOffset.Now,
+                BumpType = classification.BumpType
+            };
+
+            // Extract issue references
+            if (config.IncludeIssueReferences)
+            {
+                entry.IssueReferences = ExtractIssueReferences(commit.Message);
+            }
+
+            // Extract PR number (usually at end of message)
+            if (config.IncludePullRequestReferences)
+            {
+                entry.PullRequestNumber = ExtractPullRequestNumber(commit.Message);
+            }
+
+            return entry;
+        }
+
+        private string[] ExtractIssueReferences(string message)
+        {
+            var matches = IssueReferencePattern.Matches(message);
+            return matches
+                .Cast<Match>()
+                .Select(m => m.Groups[1].Value)
+                .Distinct()
+                .ToArray();
+        }
+
+        private string ExtractPullRequestNumber(string message)
+        {
+            var match = PullRequestPattern.Match(message);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        private List<ChangelogSection> GroupEntriesIntoSections(List<ChangelogEntry> entries, ChangelogConfig config)
+        {
+            var sections = new List<ChangelogSection>();
+
+            // Handle breaking changes separately if configured
+            if (config.GroupBreakingChanges)
+            {
+                var breakingEntries = entries.Where(e => e.IsBreakingChange).ToList();
+                if (breakingEntries.Any())
+                {
+                    var breakingSection = config.Sections.FirstOrDefault(s =>
+                        s.CommitTypes.Contains("breaking"))
+                        ?? new ChangelogSectionConfig
+                        {
+                            Title = "Breaking Changes",
+                            Emoji = "💥",
+                            Order = 0
+                        };
+
+                    sections.Add(new ChangelogSection
+                    {
+                        Title = breakingSection.Title,
+                        Emoji = breakingSection.Emoji,
+                        Order = breakingSection.Order,
+                        Entries = LimitEntries(breakingEntries, config),
+                        ShowIfEmpty = breakingSection.ShowIfEmpty
+                    });
+
+                    // Remove breaking changes from further processing
+                    entries = entries.Where(e => !e.IsBreakingChange).ToList();
+                }
+            }
+
+            // Group remaining entries by section
+            foreach (var sectionConfig in config.Sections.OrderBy(s => s.Order))
+            {
+                // Skip breaking changes section if we already handled it
+                if (config.GroupBreakingChanges && sectionConfig.CommitTypes.Contains("breaking"))
+                    continue;
+
+                var sectionEntries = entries
+                    .Where(e => sectionConfig.CommitTypes.Contains(e.Type.ToLowerInvariant()))
+                    .ToList();
+
+                if (sectionEntries.Any() || sectionConfig.ShowIfEmpty)
+                {
+                    sections.Add(new ChangelogSection
+                    {
+                        Title = sectionConfig.Title,
+                        Emoji = sectionConfig.Emoji,
+                        CommitTypes = sectionConfig.CommitTypes,
+                        Order = sectionConfig.Order,
+                        Entries = LimitEntries(sectionEntries, config),
+                        ShowIfEmpty = sectionConfig.ShowIfEmpty
+                    });
+                }
+            }
+
+            return sections.OrderBy(s => s.Order).ToList();
+        }
+
+        private List<ChangelogEntry> LimitEntries(List<ChangelogEntry> entries, ChangelogConfig config)
+        {
+            if (config.MaxEntriesPerSection > 0 && entries.Count > config.MaxEntriesPerSection)
+            {
+                return entries.Take(config.MaxEntriesPerSection).ToList();
+            }
+            return entries;
+        }
+
+        public string FormatAsMarkdown(Changelog changelog, ChangelogConfig config)
+        {
+            var sb = new StringBuilder();
+
+            // Header
+            var projectPrefix = !string.IsNullOrEmpty(changelog.ProjectName)
+                ? $"{changelog.ProjectName} "
+                : "";
+
+            sb.AppendLine($"## {projectPrefix}v{changelog.Version} ({changelog.Date:yyyy-MM-dd})");
+            sb.AppendLine();
+
+            // Add summary if there's a previous version
+            if (!string.IsNullOrEmpty(changelog.PreviousVersion))
+            {
+                var bumpTypeText = changelog.BumpType switch
+                {
+                    VersionBumpType.Major => "**Major release**",
+                    VersionBumpType.Minor => "**Minor release**",
+                    VersionBumpType.Patch => "**Patch release**",
+                    _ => "Release"
+                };
+                sb.AppendLine($"{bumpTypeText} - {changelog.TotalCommits} commit(s) by {changelog.ContributorCount} contributor(s)");
+                sb.AppendLine();
+            }
+
+            // Sections
+            foreach (var section in changelog.Sections.Where(s => s.Entries.Any() || s.ShowIfEmpty))
+            {
+                sb.AppendLine($"### {section.Emoji} {section.Title}");
+                sb.AppendLine();
+
+                if (!section.Entries.Any())
+                {
+                    sb.AppendLine("_No changes_");
+                    sb.AppendLine();
+                    continue;
+                }
+
+                foreach (var entry in section.Entries)
+                {
+                    sb.Append("- ");
+
+                    // Add scope if enabled and present
+                    if (config.IncludeScopes && !string.IsNullOrEmpty(entry.Scope))
+                    {
+                        sb.Append($"**{entry.Scope}:** ");
+                    }
+
+                    // Add description
+                    sb.Append(entry.Description);
+
+                    // Add issue references
+                    if (config.IncludeIssueReferences && entry.IssueReferences.Length > 0)
+                    {
+                        foreach (var issue in entry.IssueReferences)
+                        {
+                            if (!string.IsNullOrEmpty(config.RepositoryUrl))
+                            {
+                                sb.Append($" [#{issue}]({config.RepositoryUrl}/issues/{issue})");
+                            }
+                            else
+                            {
+                                sb.Append($" #{issue}");
+                            }
+                        }
+                    }
+
+                    // Add PR reference
+                    if (config.IncludePullRequestReferences && !string.IsNullOrEmpty(entry.PullRequestNumber))
+                    {
+                        if (!string.IsNullOrEmpty(config.RepositoryUrl))
+                        {
+                            sb.Append($" ([#{entry.PullRequestNumber}]({config.RepositoryUrl}/pull/{entry.PullRequestNumber}))");
+                        }
+                        else
+                        {
+                            sb.Append($" (#{entry.PullRequestNumber})");
+                        }
+                    }
+
+                    // Add commit link
+                    if (config.IncludeCommitLinks && !string.IsNullOrEmpty(entry.CommitSha))
+                    {
+                        if (!string.IsNullOrEmpty(config.RepositoryUrl))
+                        {
+                            sb.Append($" ([{entry.CommitSha}]({config.RepositoryUrl}/commit/{entry.CommitSha}))");
+                        }
+                        else
+                        {
+                            sb.Append($" ({entry.CommitSha})");
+                        }
+                    }
+
+                    // Add author if enabled
+                    if (config.IncludeAuthors && !string.IsNullOrEmpty(entry.Author))
+                    {
+                        sb.Append($" - @{entry.Author}");
+                    }
+
+                    sb.AppendLine();
+
+                    // Add breaking change description if present
+                    if (entry.IsBreakingChange && !string.IsNullOrEmpty(entry.BreakingChangeDescription))
+                    {
+                        sb.AppendLine($"  > ⚠️ **BREAKING:** {entry.BreakingChangeDescription}");
+                    }
+                }
+
+                sb.AppendLine();
+            }
+
+            // Contributors section
+            if (changelog.Contributors.Any() && config.IncludeAuthors)
+            {
+                sb.AppendLine("### 👥 Contributors");
+                sb.AppendLine();
+                foreach (var contributor in changelog.Contributors)
+                {
+                    sb.AppendLine($"- @{contributor}");
+                }
+                sb.AppendLine();
+            }
+
+            return sb.ToString();
+        }
+
+        public string FormatAsText(Changelog changelog, ChangelogConfig config)
+        {
+            var sb = new StringBuilder();
+
+            // Header
+            var projectPrefix = !string.IsNullOrEmpty(changelog.ProjectName)
+                ? $"{changelog.ProjectName} "
+                : "";
+
+            sb.AppendLine($"{projectPrefix}v{changelog.Version} ({changelog.Date:yyyy-MM-dd})");
+            sb.AppendLine(new string('=', 60));
+            sb.AppendLine();
+
+            // Summary
+            if (!string.IsNullOrEmpty(changelog.PreviousVersion))
+            {
+                var bumpTypeText = changelog.BumpType switch
+                {
+                    VersionBumpType.Major => "MAJOR release",
+                    VersionBumpType.Minor => "MINOR release",
+                    VersionBumpType.Patch => "PATCH release",
+                    _ => "Release"
+                };
+                sb.AppendLine($"{bumpTypeText} - {changelog.TotalCommits} commit(s) by {changelog.ContributorCount} contributor(s)");
+                sb.AppendLine();
+            }
+
+            // Sections
+            foreach (var section in changelog.Sections.Where(s => s.Entries.Any() || s.ShowIfEmpty))
+            {
+                sb.AppendLine($"{section.Title}");
+                sb.AppendLine(new string('-', section.Title.Length));
+                sb.AppendLine();
+
+                if (!section.Entries.Any())
+                {
+                    sb.AppendLine("  No changes");
+                    sb.AppendLine();
+                    continue;
+                }
+
+                foreach (var entry in section.Entries)
+                {
+                    sb.Append("  * ");
+
+                    if (config.IncludeScopes && !string.IsNullOrEmpty(entry.Scope))
+                    {
+                        sb.Append($"[{entry.Scope}] ");
+                    }
+
+                    sb.Append(entry.Description);
+
+                    if (config.IncludeIssueReferences && entry.IssueReferences.Length > 0)
+                    {
+                        sb.Append($" (#{string.Join(", #", entry.IssueReferences)})");
+                    }
+
+                    if (!string.IsNullOrEmpty(entry.CommitSha))
+                    {
+                        sb.Append($" ({entry.CommitSha})");
+                    }
+
+                    if (config.IncludeAuthors && !string.IsNullOrEmpty(entry.Author))
+                    {
+                        sb.Append($" - {entry.Author}");
+                    }
+
+                    sb.AppendLine();
+
+                    if (entry.IsBreakingChange && !string.IsNullOrEmpty(entry.BreakingChangeDescription))
+                    {
+                        sb.AppendLine($"    WARNING: {entry.BreakingChangeDescription}");
+                    }
+                }
+
+                sb.AppendLine();
+            }
+
+            // Contributors
+            if (changelog.Contributors.Any() && config.IncludeAuthors)
+            {
+                sb.AppendLine("Contributors");
+                sb.AppendLine("-----------");
+                sb.AppendLine();
+                foreach (var contributor in changelog.Contributors)
+                {
+                    sb.AppendLine($"  * {contributor}");
+                }
+                sb.AppendLine();
+            }
+
+            return sb.ToString();
+        }
+
+        public string FormatAsJson(Changelog changelog)
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+
+            return JsonSerializer.Serialize(changelog, options);
+        }
+    }
+}

--- a/Mister.Version.Core/Services/IChangelogGenerator.cs
+++ b/Mister.Version.Core/Services/IChangelogGenerator.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using LibGit2Sharp;
+using Mister.Version.Core.Models;
+
+namespace Mister.Version.Core.Services
+{
+    /// <summary>
+    /// Service for generating changelogs from commit history
+    /// </summary>
+    public interface IChangelogGenerator
+    {
+        /// <summary>
+        /// Generate a changelog from commits
+        /// </summary>
+        /// <param name="commits">List of commits to analyze</param>
+        /// <param name="version">Version for this changelog</param>
+        /// <param name="previousVersion">Previous version</param>
+        /// <param name="config">Changelog configuration</param>
+        /// <param name="conventionalCommitConfig">Conventional commit configuration for classification</param>
+        /// <param name="projectName">Project name (optional, for monorepo scenarios)</param>
+        /// <returns>Generated changelog</returns>
+        Changelog GenerateChangelog(
+            IEnumerable<Commit> commits,
+            string version,
+            string previousVersion,
+            ChangelogConfig config,
+            ConventionalCommitConfig conventionalCommitConfig,
+            string projectName = null);
+
+        /// <summary>
+        /// Format a changelog as markdown
+        /// </summary>
+        /// <param name="changelog">Changelog to format</param>
+        /// <param name="config">Changelog configuration</param>
+        /// <returns>Markdown-formatted changelog</returns>
+        string FormatAsMarkdown(Changelog changelog, ChangelogConfig config);
+
+        /// <summary>
+        /// Format a changelog as plain text
+        /// </summary>
+        /// <param name="changelog">Changelog to format</param>
+        /// <param name="config">Changelog configuration</param>
+        /// <returns>Plain text changelog</returns>
+        string FormatAsText(Changelog changelog, ChangelogConfig config);
+
+        /// <summary>
+        /// Format a changelog as JSON
+        /// </summary>
+        /// <param name="changelog">Changelog to format</param>
+        /// <returns>JSON-formatted changelog</returns>
+        string FormatAsJson(Changelog changelog);
+    }
+}


### PR DESCRIPTION
- Create changelog models (Changelog, ChangelogEntry, ChangelogSection, ChangelogConfig)
- Implement IChangelogGenerator interface and ChangelogGenerator class
- Support multiple output formats (Markdown, Plain Text, JSON)
- Extract GitHub issue and PR references from commit messages
- Group commits by type (Breaking Changes, Features, Fixes, etc.)
- Add configurable sections with emojis and custom grouping
- Implement mr-version changelog CLI command
- Add changelog configuration to VersionConfig.cs
- CLI options for version range, output format, and customization
- Repository URL support for generating clickable links
- Breaking change descriptions and highlighting
- Contributor listing and commit statistics

Example usage:
  mr-version changelog                     # Generate from last tag to HEAD
  mr-version changelog --from 2.2.0 --to 2.3.0
  mr-version changelog --output json
  mr-version changelog --output-file CHANGELOG.md
  mr-version changelog --repo-url https://github.com/owner/repo