### PR TITLE
docs: Update package READMEs with v3.0.0 version and features

### DIFF
--- a/Mister.Version.CLI/README.md
+++ b/Mister.Version.CLI/README.md
@@ -1,6 +1,6 @@
 # Mister.Version CLI
 
-![version](https://img.shields.io/badge/version-1.1.0-blue.svg)
+![version](https://img.shields.io/badge/version-3.0.0-blue.svg)
 ![.NET](https://img.shields.io/badge/.NET-8.0-purple.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
@@ -8,24 +8,26 @@ Command-line tool for analyzing, reporting, and managing versions across your .N
 
 ## Features
 
-- Generate version reports in multiple formats (text, JSON, CSV, dependency graphs)
-- Calculate versions for individual projects
-- Visualize dependency graphs (Mermaid, DOT, ASCII)
-- Branch-aware versioning with detailed change tracking
+- **Version Reports**: Generate reports in multiple formats (text, JSON, CSV, dependency graphs)
+- **Version Calculation**: Calculate versions for individual projects with detailed reasoning
+- **Changelog Generation**: Automatically generate changelogs from conventional commits
+- **Dependency Visualization**: Visualize dependency graphs (Mermaid, DOT, ASCII)
+- **Conventional Commits**: Smart semantic versioning based on commit message conventions
+- **Branch-Aware Versioning**: Different strategies for main, dev, release, and feature branches
 
 ## Installation
 
 ### Global Tool
 
 ```bash
-dotnet tool install --global Mister.Version.CLI --version 1.1.0
+dotnet tool install --global Mister.Version.CLI --version 3.0.0
 ```
 
 ### Local Tool
 
 ```bash
 dotnet new tool-manifest  # if you don't have one already
-dotnet tool install --local Mister.Version.CLI --version 1.1.0
+dotnet tool install --local Mister.Version.CLI --version 3.0.0
 ```
 
 ## Quick Reference
@@ -63,6 +65,24 @@ mr-version version -p src/MyProject/MyProject.csproj -d
 
 # JSON output
 mr-version version -p src/MyProject/MyProject.csproj -j
+```
+
+### Generate Changelog
+
+```bash
+# Generate changelog from last tag to HEAD
+mr-version changelog
+
+# Generate for specific version range
+mr-version changelog --from 2.2.0 --to 2.3.0
+
+# Output to file
+mr-version changelog --output-file CHANGELOG.md
+
+# Different formats
+mr-version changelog --output markdown  # Markdown (default)
+mr-version changelog --output text      # Plain text
+mr-version changelog --output json      # JSON
 ```
 
 ### Common Options

--- a/Mister.Version/README.md
+++ b/Mister.Version/README.md
@@ -1,6 +1,6 @@
 # Mister.Version MSBuild Integration
 
-![version](https://img.shields.io/badge/version-1.1.0-blue.svg)
+![version](https://img.shields.io/badge/version-3.0.0-blue.svg)
 ![.NET](https://img.shields.io/badge/.NET-8.0-purple.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
@@ -9,6 +9,9 @@ MSBuild integration package for Mister.Version, enabling automatic version calcu
 ## Features
 
 - **Automatic Version Calculation**: Generates semantic versions based on git history and changes
+- **Conventional Commits Support**: Intelligent semantic versioning based on commit message conventions
+- **Automatic Changelog Generation**: Generate changelogs from conventional commits during build
+- **File Pattern-Based Change Detection**: Smart versioning based on which files changed
 - **Monorepo Support**: Independent versioning for multiple projects in a single repository
 - **MSBuild Integration**: Seamless integration with the .NET build process
 - **Cross-Platform**: Works on Windows, macOS, and Linux
@@ -25,7 +28,7 @@ dotnet add package Mister.Version
 Or add to your project file:
 
 ```xml
-<PackageReference Include="Mister.Version" Version="1.1.0" />
+<PackageReference Include="Mister.Version" Version="3.0.0" />
 ```
 
 ## Usage
@@ -50,6 +53,14 @@ Once installed, Mister.Version automatically calculates and injects version info
 
 The tool will automatically calculate versions based on your git history and changes.
 
+## What's New in v3.0
+
+- **Conventional Commits**: Enable semantic versioning based on commit message conventions
+- **Changelog Generation**: Automatically generate changelogs during build
+- **File Pattern Detection**: Control version bumps based on which files changed
+- **Git Enhancements**: Shallow clone support, custom tag patterns, submodule detection
+- **Additional Directory Monitoring**: Track changes in shared libraries outside project directory
+
 ## Configuration
 
 Configure behavior using MSBuild properties:
@@ -59,6 +70,17 @@ Configure behavior using MSBuild properties:
   <MonoRepoDebug>true</MonoRepoDebug>
   <MonoRepoTagPrefix>v</MonoRepoTagPrefix>
   <MonoRepoPrereleaseType>beta</MonoRepoPrereleaseType>
+
+  <!-- Enable conventional commits for semantic versioning -->
+  <MonoRepoConventionalCommitsEnabled>true</MonoRepoConventionalCommitsEnabled>
+
+  <!-- Enable file pattern-based change detection -->
+  <MonoRepoChangeDetectionEnabled>true</MonoRepoChangeDetectionEnabled>
+  <MonoRepoIgnoreFilePatterns>**/*.md;**/docs/**</MonoRepoIgnoreFilePatterns>
+
+  <!-- Enable automatic changelog generation -->
+  <MonoRepoGenerateChangelog>true</MonoRepoGenerateChangelog>
+  <MonoRepoChangelogFormat>markdown</MonoRepoChangelogFormat>
 </PropertyGroup>
 ```
 
@@ -68,6 +90,9 @@ Common properties:
 - `MonoRepoTagPrefix` - Version tag prefix (default: `v`)
 - `MonoRepoPrereleaseType` - Prerelease type (none, alpha, beta, rc)
 - `MonoRepoConfigFile` - Path to YAML configuration file
+- `MonoRepoConventionalCommitsEnabled` - Enable conventional commits analysis
+- `MonoRepoChangeDetectionEnabled` - Enable file pattern-based change detection
+- `MonoRepoGenerateChangelog` - Generate changelog during build
 
 ## Documentation
 


### PR DESCRIPTION
- Update version badges from 1.1.0 to 3.0.0
- Add v3.0 features to CLI README:
  * Changelog generation command
  * Conventional commits support
  * Enhanced feature descriptions
- Add v3.0 features to MSBuild README:
  * Conventional commits configuration
  * File pattern-based change detection
  * Changelog generation during build
  * New "What's New in v3.0" section
- Update installation instructions with correct version