### PR TITLE
Add licensing to NuGet package push

### DIFF
--- a/Project.props
+++ b/Project.props
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<Version>3.0.0-alpha.3</Version>
-		<License>MIT</License>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>icon.png</PackageIcon>
 	</PropertyGroup>


### PR DESCRIPTION
Changed `<License>MIT</License>` to `<PackageLicenseExpression>MIT</PackageLicenseExpression>` in Project.props to properly specify the MIT license for NuGet packages.
