### PR TITLE
Integrate GetVersion into change detection

### DIFF
--- a/Mister.Version.Core/Services/HasChangesService.cs
+++ b/Mister.Version.Core/Services/HasChangesService.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using LibGit2Sharp;
+using Mister.Version.Core.Models;
+
+namespace Mister.Version.Core.Services
+{
+    /// <summary>
+    /// Lightweight service for detecting changes in a project without calculating a full version.
+    /// </summary>
+    public class HasChangesService : IDisposable
+    {
+        private readonly IGitService _gitService;
+        private readonly Action<string, string> _logger;
+        private readonly string _repoRoot;
+        private bool _disposed = false;
+
+        public HasChangesService(string repoRoot, Action<string, string> logger)
+        {
+            _repoRoot = repoRoot;
+            _logger = logger ?? ((level, message) => { });
+            _gitService = new GitService(repoRoot, null, _logger);
+        }
+
+        /// <summary>
+        /// Detects changes for a project since a specific tag or commit.
+        /// </summary>
+        /// <param name="request">Change detection request</param>
+        /// <returns>Change detection result</returns>
+        public HasChangesResult DetectChanges(HasChangesRequest request)
+        {
+            try
+            {
+                _logger("Debug", $"[HasChanges] Starting change detection for: {request.ProjectPath}");
+
+                var projectName = Path.GetFileNameWithoutExtension(request.ProjectPath);
+
+                // Find the commit to compare against
+                Commit compareCommit = null;
+                string comparedAgainst = null;
+
+                if (!string.IsNullOrEmpty(request.SinceCommit))
+                {
+                    // Use specific commit SHA
+                    compareCommit = FindCommitBySha(request.SinceCommit);
+                    comparedAgainst = request.SinceCommit.Length > 7
+                        ? request.SinceCommit.Substring(0, 7)
+                        : request.SinceCommit;
+
+                    if (compareCommit == null)
+                    {
+                        _logger("Warning", $"[HasChanges] Commit {request.SinceCommit} not found");
+                        return new HasChangesResult
+                        {
+                            HasChanges = true,
+                            ChangeType = VersionBumpType.Patch,
+                            Reason = $"Commit {request.SinceCommit} not found, assuming changes",
+                            ComparedAgainst = "unknown"
+                        };
+                    }
+                }
+                else if (!string.IsNullOrEmpty(request.SinceTag))
+                {
+                    // Use specific tag
+                    var tag = FindTag(request.SinceTag);
+                    if (tag != null)
+                    {
+                        compareCommit = PeelTagToCommit(tag);
+                        comparedAgainst = request.SinceTag;
+                    }
+                    else
+                    {
+                        _logger("Warning", $"[HasChanges] Tag {request.SinceTag} not found");
+                        return new HasChangesResult
+                        {
+                            HasChanges = true,
+                            ChangeType = VersionBumpType.Patch,
+                            Reason = $"Tag {request.SinceTag} not found, assuming changes",
+                            ComparedAgainst = "unknown"
+                        };
+                    }
+                }
+                else
+                {
+                    // Find the latest version tag for this project
+                    var branchType = _gitService.GetBranchType(_gitService.CurrentBranch);
+                    var versionOptions = new VersionOptions
+                    {
+                        TagPrefix = request.TagPrefix,
+                        ProjectName = projectName
+                    };
+
+                    // Try project-specific tag first
+                    var projectTag = _gitService.GetProjectVersionTag(projectName, branchType, request.TagPrefix, versionOptions);
+                    if (projectTag?.Commit != null)
+                    {
+                        compareCommit = projectTag.Commit;
+                        comparedAgainst = projectTag.Tag?.FriendlyName ?? $"{projectName}-{request.TagPrefix}{projectTag.SemVer}";
+                    }
+                    else
+                    {
+                        // Fall back to global tag
+                        var globalTag = _gitService.GetGlobalVersionTag(branchType, versionOptions);
+                        if (globalTag?.Commit != null)
+                        {
+                            compareCommit = globalTag.Commit;
+                            comparedAgainst = globalTag.Tag?.FriendlyName ?? $"{request.TagPrefix}{globalTag.SemVer}";
+                        }
+                    }
+                }
+
+                // If no commit to compare against, assume this is a new project
+                if (compareCommit == null)
+                {
+                    _logger("Info", "[HasChanges] No previous version tag found, treating as new project");
+                    return new HasChangesResult
+                    {
+                        HasChanges = true,
+                        ChangeType = VersionBumpType.Minor,
+                        Reason = "No previous version tag found (new project)",
+                        ComparedAgainst = "none",
+                        ChangedFiles = GetAllProjectFiles(request)
+                    };
+                }
+
+                // Get relative project path
+                var projectDir = Path.GetDirectoryName(request.ProjectPath);
+                string relativeProjectPath;
+#if NET472
+                relativeProjectPath = PathUtils.GetRelativePath(request.RepoRoot, projectDir ?? request.ProjectPath);
+#else
+                relativeProjectPath = Path.GetRelativePath(request.RepoRoot, projectDir ?? request.ProjectPath);
+#endif
+
+                // Check if change detection with classification is enabled
+                if (request.ChangeDetectionEnabled)
+                {
+                    var config = new ChangeDetectionConfig
+                    {
+                        Enabled = true,
+                        IgnorePatterns = request.IgnorePatterns,
+                        MajorPatterns = request.MajorPatterns,
+                        MinorPatterns = request.MinorPatterns,
+                        PatchPatterns = request.PatchPatterns,
+                        AdditionalMonitorPaths = request.AdditionalMonitorPaths
+                    };
+
+                    var classification = _gitService.ClassifyProjectChanges(
+                        compareCommit,
+                        relativeProjectPath,
+                        request.Dependencies,
+                        request.RepoRoot,
+                        config);
+
+                    var changedFiles = new List<string>();
+                    changedFiles.AddRange(classification.MajorFiles ?? new List<string>());
+                    changedFiles.AddRange(classification.MinorFiles ?? new List<string>());
+                    changedFiles.AddRange(classification.PatchFiles ?? new List<string>());
+                    changedFiles.AddRange(classification.UnclassifiedFiles ?? new List<string>());
+
+                    return new HasChangesResult
+                    {
+                        HasChanges = !classification.ShouldIgnore && changedFiles.Count > 0,
+                        ChangeType = classification.RequiredBumpType,
+                        Reason = classification.Reason,
+                        ComparedAgainst = comparedAgainst,
+                        ChangedFiles = changedFiles,
+                        MajorFiles = classification.MajorFiles ?? new List<string>(),
+                        MinorFiles = classification.MinorFiles ?? new List<string>(),
+                        PatchFiles = classification.PatchFiles ?? new List<string>(),
+                        IgnoredFiles = classification.IgnoredFiles ?? new List<string>()
+                    };
+                }
+                else
+                {
+                    // Simple change detection without classification
+                    var hasChanges = _gitService.ProjectHasChangedSinceTag(
+                        compareCommit,
+                        relativeProjectPath,
+                        request.Dependencies,
+                        request.RepoRoot,
+                        request.Debug);
+
+                    if (hasChanges)
+                    {
+                        // Get the list of changed files
+                        var changedFiles = GetChangedFiles(compareCommit, relativeProjectPath, request);
+
+                        return new HasChangesResult
+                        {
+                            HasChanges = true,
+                            ChangeType = VersionBumpType.Patch,
+                            Reason = $"Changes detected since {comparedAgainst}",
+                            ComparedAgainst = comparedAgainst,
+                            ChangedFiles = changedFiles
+                        };
+                    }
+                    else
+                    {
+                        return new HasChangesResult
+                        {
+                            HasChanges = false,
+                            ChangeType = VersionBumpType.None,
+                            Reason = $"No changes since {comparedAgainst}",
+                            ComparedAgainst = comparedAgainst,
+                            ChangedFiles = new List<string>()
+                        };
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger("Error", $"[HasChanges] Failed to detect changes: {ex.Message}");
+                return new HasChangesResult
+                {
+                    HasChanges = true,
+                    ChangeType = VersionBumpType.Patch,
+                    Reason = $"Error detecting changes: {ex.Message}",
+                    ComparedAgainst = "error"
+                };
+            }
+        }
+
+        private Commit FindCommitBySha(string sha)
+        {
+            try
+            {
+                return _gitService.Repository.Lookup<Commit>(sha);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private Tag FindTag(string tagName)
+        {
+            return _gitService.Repository.Tags.FirstOrDefault(t =>
+                t.FriendlyName.Equals(tagName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private Commit PeelTagToCommit(Tag tag)
+        {
+            GitObject target = tag.Target;
+            while (target is TagAnnotation annotation)
+                target = annotation.Target;
+            return target as Commit;
+        }
+
+        private List<string> GetChangedFiles(Commit sinceCommit, string projectPath, HasChangesRequest request)
+        {
+            var changedFiles = new List<string>();
+
+            try
+            {
+                var headCommit = _gitService.Repository.Head.Tip;
+                if (headCommit == null)
+                    return changedFiles;
+
+                var diff = _gitService.Repository.Diff.Compare<TreeChanges>(
+                    sinceCommit.Tree,
+                    headCommit.Tree);
+
+                var normalizedProjectPath = NormalizePath(projectPath);
+
+                // Add direct project changes
+                foreach (var change in diff)
+                {
+                    var normalizedPath = NormalizePath(change.Path);
+                    if (normalizedPath.StartsWith(normalizedProjectPath))
+                    {
+                        changedFiles.Add(change.Path);
+                    }
+                }
+
+                // Add dependency changes
+                if (request.Dependencies != null)
+                {
+                    foreach (var dependency in request.Dependencies)
+                    {
+#if NET472
+                        var relativeDependencyPath = NormalizePath(PathUtils.GetRelativePath(request.RepoRoot, dependency));
+#else
+                        var relativeDependencyPath = NormalizePath(Path.GetRelativePath(request.RepoRoot, dependency));
+#endif
+                        var dependencyDirectory = NormalizePath(Path.GetDirectoryName(relativeDependencyPath) ?? relativeDependencyPath);
+
+                        foreach (var change in diff)
+                        {
+                            var normalizedPath = NormalizePath(change.Path);
+                            if (normalizedPath.StartsWith(dependencyDirectory))
+                            {
+                                changedFiles.Add(change.Path);
+                            }
+                        }
+                    }
+                }
+
+                // Add additional monitor path changes
+                if (request.AdditionalMonitorPaths != null)
+                {
+                    foreach (var monitorPath in request.AdditionalMonitorPaths)
+                    {
+                        if (string.IsNullOrWhiteSpace(monitorPath))
+                            continue;
+
+                        string normalizedMonitorPath;
+                        if (Path.IsPathRooted(monitorPath))
+                        {
+#if NET472
+                            normalizedMonitorPath = NormalizePath(PathUtils.GetRelativePath(request.RepoRoot, monitorPath));
+#else
+                            normalizedMonitorPath = NormalizePath(Path.GetRelativePath(request.RepoRoot, monitorPath));
+#endif
+                        }
+                        else
+                        {
+                            normalizedMonitorPath = NormalizePath(monitorPath);
+                        }
+
+                        foreach (var change in diff)
+                        {
+                            var normalizedPath = NormalizePath(change.Path);
+                            if (normalizedPath.StartsWith(normalizedMonitorPath))
+                            {
+                                changedFiles.Add(change.Path);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger("Warning", $"[HasChanges] Error getting changed files: {ex.Message}");
+            }
+
+            return changedFiles.Distinct().ToList();
+        }
+
+        private List<string> GetAllProjectFiles(HasChangesRequest request)
+        {
+            var files = new List<string>();
+            try
+            {
+                var projectDir = Path.GetDirectoryName(request.ProjectPath);
+                if (!string.IsNullOrEmpty(projectDir) && Directory.Exists(projectDir))
+                {
+                    files.AddRange(Directory.GetFiles(projectDir, "*", SearchOption.AllDirectories)
+                        .Select(f => Path.GetRelativePath(request.RepoRoot, f)));
+                }
+            }
+            catch
+            {
+                // Ignore errors reading files
+            }
+            return files;
+        }
+
+        private static string NormalizePath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return string.Empty;
+            return path.Replace('\\', '/');
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _gitService?.Dispose();
+                _disposed = true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Request object for change detection
+    /// </summary>
+    public class HasChangesRequest
+    {
+        public string ProjectPath { get; set; }
+        public string RepoRoot { get; set; }
+        public List<string> Dependencies { get; set; }
+        public string TagPrefix { get; set; } = "v";
+        public string SinceTag { get; set; }
+        public string SinceCommit { get; set; }
+        public bool ChangeDetectionEnabled { get; set; } = false;
+        public List<string> IgnorePatterns { get; set; }
+        public List<string> MajorPatterns { get; set; }
+        public List<string> MinorPatterns { get; set; }
+        public List<string> PatchPatterns { get; set; }
+        public List<string> AdditionalMonitorPaths { get; set; }
+        public bool Debug { get; set; } = false;
+    }
+
+    /// <summary>
+    /// Result object for change detection
+    /// </summary>
+    public class HasChangesResult
+    {
+        public bool HasChanges { get; set; }
+        public VersionBumpType ChangeType { get; set; }
+        public string Reason { get; set; }
+        public string ComparedAgainst { get; set; }
+        public List<string> ChangedFiles { get; set; } = new List<string>();
+        public List<string> MajorFiles { get; set; } = new List<string>();
+        public List<string> MinorFiles { get; set; } = new List<string>();
+        public List<string> PatchFiles { get; set; } = new List<string>();
+        public List<string> IgnoredFiles { get; set; } = new List<string>();
+    }
+}

--- a/Mister.Version.Tests/HasChangesTaskTests.cs
+++ b/Mister.Version.Tests/HasChangesTaskTests.cs
@@ -1,0 +1,535 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using LibGit2Sharp;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Mister.Version.Core.Models;
+using Mister.Version.Core.Services;
+
+namespace Mister.Version.Tests
+{
+    public class HasChangesTaskTests : IDisposable
+    {
+        private readonly string _testRepoRoot;
+        private readonly string _testProjectPath;
+        private Repository _repository;
+
+        public HasChangesTaskTests()
+        {
+            _testRepoRoot = Path.Combine(Path.GetTempPath(), "test-haschanges-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testRepoRoot);
+
+            // Initialize git repository
+            Repository.Init(_testRepoRoot);
+            _repository = new Repository(_testRepoRoot);
+
+            var projectDir = Path.Combine(_testRepoRoot, "src", "TestProject");
+            Directory.CreateDirectory(projectDir);
+            _testProjectPath = Path.Combine(projectDir, "TestProject.csproj");
+
+            // Create a minimal project file
+            File.WriteAllText(_testProjectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>");
+
+            // Create initial commit
+            Commands.Stage(_repository, "*");
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.Commit("Initial commit", signature, signature);
+        }
+
+        [Fact]
+        public void HasChangesTask_RequiredPropertiesValidation()
+        {
+            // Arrange
+            var task = new HasChangesTask();
+            var buildEngine = new MockBuildEngine();
+            task.BuildEngine = buildEngine;
+
+            // Act & Assert - Missing required properties should fail
+            var result = task.Execute();
+            Assert.False(result);
+            Assert.True(buildEngine.Errors.Count > 0);
+        }
+
+        [Fact]
+        public void HasChangesTask_DefaultPropertyValues()
+        {
+            // Arrange
+            var task = new HasChangesTask();
+
+            // Assert default values
+            Assert.Equal("v", task.TagPrefix);
+            Assert.False(task.Debug);
+            Assert.False(task.ChangeDetectionEnabled);
+            Assert.Null(task.SinceTag);
+            Assert.Null(task.SinceCommit);
+        }
+
+        [Fact]
+        public void HasChangesTask_DetectsChangesInNewProject()
+        {
+            // Arrange
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.True(task.HasChanges); // New project should have changes
+            Assert.NotNull(task.ChangeType);
+            Assert.NotEmpty(task.ChangeReason);
+        }
+
+        [Fact]
+        public void HasChangesTask_NoChangesAfterTag()
+        {
+            // Arrange - Create a tag at current commit
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.ApplyTag("v1.0.0");
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                SinceTag = "v1.0.0",
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.False(task.HasChanges); // No changes since tag
+            Assert.Equal("None", task.ChangeType);
+            Assert.Equal("v1.0.0", task.ComparedAgainst);
+        }
+
+        [Fact]
+        public void HasChangesTask_DetectsChangesAfterTag()
+        {
+            // Arrange - Create a tag, then make changes
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.ApplyTag("v1.0.0");
+
+            // Make a change
+            var newFile = Path.Combine(Path.GetDirectoryName(_testProjectPath), "NewClass.cs");
+            File.WriteAllText(newFile, "public class NewClass { }");
+            Commands.Stage(_repository, "*");
+            _repository.Commit("Add new class", signature, signature);
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                SinceTag = "v1.0.0",
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.True(task.HasChanges);
+            Assert.NotEqual("None", task.ChangeType);
+            Assert.NotNull(task.ChangedFiles);
+            Assert.True(task.ChangedFiles.Length > 0);
+        }
+
+        [Fact]
+        public void HasChangesTask_DependenciesHandling()
+        {
+            // Arrange
+            var dependencies = new[]
+            {
+                new TaskItem("../SharedLib/SharedLib.csproj"),
+                new TaskItem("../Common/Common.csproj")
+            };
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                Dependencies = dependencies,
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Assert
+            Assert.NotNull(task.Dependencies);
+            Assert.Equal(2, task.Dependencies.Length);
+        }
+
+        [Fact]
+        public void HasChangesTask_DetectsDependencyChanges()
+        {
+            // Arrange - Create dependency project
+            var sharedLibDir = Path.Combine(_testRepoRoot, "src", "SharedLib");
+            Directory.CreateDirectory(sharedLibDir);
+            var sharedLibPath = Path.Combine(sharedLibDir, "SharedLib.csproj");
+            File.WriteAllText(sharedLibPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>");
+
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            Commands.Stage(_repository, "*");
+            _repository.Commit("Add shared lib", signature, signature);
+
+            // Create a tag
+            _repository.ApplyTag("v1.0.0");
+
+            // Make a change to the dependency
+            var depFile = Path.Combine(sharedLibDir, "Helper.cs");
+            File.WriteAllText(depFile, "public class Helper { }");
+            Commands.Stage(_repository, "*");
+            _repository.Commit("Add helper to shared lib", signature, signature);
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                SinceTag = "v1.0.0",
+                Dependencies = new[] { new TaskItem(sharedLibPath) as ITaskItem },
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.True(task.HasChanges); // Dependency changed
+        }
+
+        [Fact]
+        public void HasChangesTask_SinceCommitWorks()
+        {
+            // Arrange - Get the current commit SHA
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            var initialCommit = _repository.Head.Tip.Sha;
+
+            // Make a change
+            var newFile = Path.Combine(Path.GetDirectoryName(_testProjectPath), "Change.cs");
+            File.WriteAllText(newFile, "public class Change { }");
+            Commands.Stage(_repository, "*");
+            _repository.Commit("Add change", signature, signature);
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                SinceCommit = initialCommit,
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.True(task.HasChanges);
+            Assert.NotNull(task.ComparedAgainst);
+        }
+
+        [Fact]
+        public void HasChangesTask_ChangeDetectionClassification()
+        {
+            // Arrange - Create a tag, then make changes
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.ApplyTag("v1.0.0");
+
+            // Make a change
+            var newFile = Path.Combine(Path.GetDirectoryName(_testProjectPath), "Feature.cs");
+            File.WriteAllText(newFile, "public class Feature { }");
+            Commands.Stage(_repository, "*");
+            _repository.Commit("Add feature", signature, signature);
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                SinceTag = "v1.0.0",
+                ChangeDetectionEnabled = true,
+                MinorFilePatterns = "**/*.cs",
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            Assert.True(task.HasChanges);
+            // With MinorFilePatterns matching *.cs, the change type should be Minor
+            Assert.Equal("Minor", task.ChangeType);
+        }
+
+        [Fact]
+        public void HasChangesTask_IgnorePatterns()
+        {
+            // Arrange - Create a tag, then make changes to ignored files
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.ApplyTag("v1.0.0");
+
+            // Make a change to a file that will be ignored
+            var docsDir = Path.Combine(Path.GetDirectoryName(_testProjectPath), "docs");
+            Directory.CreateDirectory(docsDir);
+            var docFile = Path.Combine(docsDir, "README.md");
+            File.WriteAllText(docFile, "# Documentation");
+            Commands.Stage(_repository, "*");
+            _repository.Commit("Add docs", signature, signature);
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                SinceTag = "v1.0.0",
+                ChangeDetectionEnabled = true,
+                IgnoreFilePatterns = "**/docs/**;**/*.md",
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            // Changes to docs should be ignored
+            Assert.False(task.HasChanges);
+            Assert.Equal("None", task.ChangeType);
+        }
+
+        [Fact]
+        public void HasChangesTask_OutputPropertiesExist()
+        {
+            // Assert - Check that output properties have the correct attributes
+            var hasChangesProperty = typeof(HasChangesTask).GetProperty("HasChanges");
+            var changeTypeProperty = typeof(HasChangesTask).GetProperty("ChangeType");
+            var changeReasonProperty = typeof(HasChangesTask).GetProperty("ChangeReason");
+            var changedFilesProperty = typeof(HasChangesTask).GetProperty("ChangedFiles");
+            var comparedAgainstProperty = typeof(HasChangesTask).GetProperty("ComparedAgainst");
+
+            Assert.NotNull(hasChangesProperty);
+            Assert.NotNull(changeTypeProperty);
+            Assert.NotNull(changeReasonProperty);
+            Assert.NotNull(changedFilesProperty);
+            Assert.NotNull(comparedAgainstProperty);
+
+            Assert.NotNull(hasChangesProperty.GetCustomAttributes(typeof(OutputAttribute), false).FirstOrDefault());
+            Assert.NotNull(changeTypeProperty.GetCustomAttributes(typeof(OutputAttribute), false).FirstOrDefault());
+            Assert.NotNull(changeReasonProperty.GetCustomAttributes(typeof(OutputAttribute), false).FirstOrDefault());
+            Assert.NotNull(changedFilesProperty.GetCustomAttributes(typeof(OutputAttribute), false).FirstOrDefault());
+            Assert.NotNull(comparedAgainstProperty.GetCustomAttributes(typeof(OutputAttribute), false).FirstOrDefault());
+        }
+
+        [Fact]
+        public void HasChangesTask_ProjectSpecificTag()
+        {
+            // Arrange - Create a project-specific tag
+            var projectName = Path.GetFileNameWithoutExtension(_testProjectPath);
+            var tagName = $"{projectName.ToLowerInvariant()}-v1.0.0";
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.ApplyTag(tagName);
+
+            var task = new HasChangesTask
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                BuildEngine = new MockBuildEngine()
+            };
+
+            // Act
+            var result = task.Execute();
+
+            // Assert
+            Assert.True(result);
+            // Should find the project-specific tag and report no changes
+            Assert.False(task.HasChanges);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _repository?.Dispose();
+                if (Directory.Exists(_testRepoRoot))
+                {
+                    // Need to handle read-only files in .git directory
+                    SetAttributesNormal(new DirectoryInfo(_testRepoRoot));
+                    Directory.Delete(_testRepoRoot, true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        private void SetAttributesNormal(DirectoryInfo dir)
+        {
+            foreach (var subDir in dir.GetDirectories())
+            {
+                SetAttributesNormal(subDir);
+            }
+            foreach (var file in dir.GetFiles())
+            {
+                file.Attributes = FileAttributes.Normal;
+            }
+        }
+    }
+
+    public class HasChangesServiceTests : IDisposable
+    {
+        private readonly string _testRepoRoot;
+        private readonly string _testProjectPath;
+        private Repository _repository;
+
+        public HasChangesServiceTests()
+        {
+            _testRepoRoot = Path.Combine(Path.GetTempPath(), "test-haschanges-svc-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testRepoRoot);
+
+            // Initialize git repository
+            Repository.Init(_testRepoRoot);
+            _repository = new Repository(_testRepoRoot);
+
+            var projectDir = Path.Combine(_testRepoRoot, "src", "TestProject");
+            Directory.CreateDirectory(projectDir);
+            _testProjectPath = Path.Combine(projectDir, "TestProject.csproj");
+
+            // Create a minimal project file
+            File.WriteAllText(_testProjectPath, @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>");
+
+            // Create initial commit
+            Commands.Stage(_repository, "*");
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.Commit("Initial commit", signature, signature);
+        }
+
+        [Fact]
+        public void HasChangesService_DetectChanges_NewProject()
+        {
+            // Arrange
+            using var service = new HasChangesService(_testRepoRoot, (level, msg) => { });
+            var request = new HasChangesRequest
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                TagPrefix = "v"
+            };
+
+            // Act
+            var result = service.DetectChanges(request);
+
+            // Assert
+            Assert.True(result.HasChanges);
+            Assert.NotNull(result.Reason);
+        }
+
+        [Fact]
+        public void HasChangesService_DetectChanges_NoChangesSinceTag()
+        {
+            // Arrange
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.ApplyTag("v1.0.0");
+
+            using var service = new HasChangesService(_testRepoRoot, (level, msg) => { });
+            var request = new HasChangesRequest
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                TagPrefix = "v",
+                SinceTag = "v1.0.0"
+            };
+
+            // Act
+            var result = service.DetectChanges(request);
+
+            // Assert
+            Assert.False(result.HasChanges);
+            Assert.Equal(VersionBumpType.None, result.ChangeType);
+        }
+
+        [Fact]
+        public void HasChangesService_DetectChanges_WithClassification()
+        {
+            // Arrange
+            var signature = new Signature("Test", "test@test.com", DateTimeOffset.Now);
+            _repository.ApplyTag("v1.0.0");
+
+            // Make a change
+            var newFile = Path.Combine(Path.GetDirectoryName(_testProjectPath), "Service.cs");
+            File.WriteAllText(newFile, "public class Service { }");
+            Commands.Stage(_repository, "*");
+            _repository.Commit("Add service", signature, signature);
+
+            using var service = new HasChangesService(_testRepoRoot, (level, msg) => { });
+            var request = new HasChangesRequest
+            {
+                ProjectPath = _testProjectPath,
+                RepoRoot = _testRepoRoot,
+                TagPrefix = "v",
+                SinceTag = "v1.0.0",
+                ChangeDetectionEnabled = true,
+                MajorPatterns = new List<string> { "**/breaking/**" },
+                MinorPatterns = new List<string> { "**/*.cs" },
+                PatchPatterns = new List<string> { "**/*.txt" }
+            };
+
+            // Act
+            var result = service.DetectChanges(request);
+
+            // Assert
+            Assert.True(result.HasChanges);
+            Assert.Equal(VersionBumpType.Minor, result.ChangeType);
+            Assert.NotEmpty(result.MinorFiles);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _repository?.Dispose();
+                if (Directory.Exists(_testRepoRoot))
+                {
+                    SetAttributesNormal(new DirectoryInfo(_testRepoRoot));
+                    Directory.Delete(_testRepoRoot, true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        private void SetAttributesNormal(DirectoryInfo dir)
+        {
+            foreach (var subDir in dir.GetDirectories())
+            {
+                SetAttributesNormal(subDir);
+            }
+            foreach (var file in dir.GetFiles())
+            {
+                file.Attributes = FileAttributes.Normal;
+            }
+        }
+    }
+}

--- a/Mister.Version/HasChangesTask.cs
+++ b/Mister.Version/HasChangesTask.cs
@@ -1,0 +1,240 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mister.Version.Core.Models;
+using Mister.Version.Core.Services;
+
+namespace Mister.Version;
+
+/// <summary>
+/// MSBuild task that detects whether a project has changes since a specific tag or commit.
+/// This is a lightweight alternative to MonoRepoVersionTask when you only need to check for changes
+/// without calculating a full version.
+/// </summary>
+public class HasChangesTask : Task
+{
+    /// <summary>
+    /// Path to the project file to check for changes
+    /// </summary>
+    [Required]
+    public string ProjectPath { get; set; }
+
+    /// <summary>
+    /// Path to start searching for the Git repository root.
+    /// If not specified, will start from the project directory.
+    /// </summary>
+    public string RepoRoot { get; set; }
+
+    /// <summary>
+    /// List of project dependencies to check for changes
+    /// </summary>
+    public ITaskItem[] Dependencies { get; set; }
+
+    /// <summary>
+    /// Custom tag prefix for version tags (default: v)
+    /// </summary>
+    public string TagPrefix { get; set; } = "v";
+
+    /// <summary>
+    /// Specific tag to compare against. If not specified, will find the latest version tag.
+    /// </summary>
+    public string SinceTag { get; set; }
+
+    /// <summary>
+    /// Specific commit SHA to compare against. Takes precedence over SinceTag.
+    /// </summary>
+    public string SinceCommit { get; set; }
+
+    /// <summary>
+    /// Enable file pattern-based change detection for classification
+    /// </summary>
+    public bool ChangeDetectionEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Semicolon-separated list of file patterns to ignore (won't count as changes)
+    /// </summary>
+    public string IgnoreFilePatterns { get; set; }
+
+    /// <summary>
+    /// Semicolon-separated list of file patterns that indicate major changes
+    /// </summary>
+    public string MajorFilePatterns { get; set; }
+
+    /// <summary>
+    /// Semicolon-separated list of file patterns that indicate minor changes
+    /// </summary>
+    public string MinorFilePatterns { get; set; }
+
+    /// <summary>
+    /// Semicolon-separated list of file patterns that indicate patch changes
+    /// </summary>
+    public string PatchFilePatterns { get; set; }
+
+    /// <summary>
+    /// Semicolon-separated list of additional directories to monitor for changes
+    /// </summary>
+    public string AdditionalMonitorPaths { get; set; }
+
+    /// <summary>
+    /// Debug mode for verbose logging
+    /// </summary>
+    public bool Debug { get; set; } = false;
+
+    /// <summary>
+    /// Output parameter indicating whether the project has changes
+    /// </summary>
+    [Output]
+    public bool HasChanges { get; set; }
+
+    /// <summary>
+    /// Output parameter containing the list of changed files
+    /// </summary>
+    [Output]
+    public ITaskItem[] ChangedFiles { get; set; }
+
+    /// <summary>
+    /// Output parameter indicating the type of change (None, Patch, Minor, Major)
+    /// </summary>
+    [Output]
+    public string ChangeType { get; set; }
+
+    /// <summary>
+    /// Output parameter with a human-readable reason for the change detection result
+    /// </summary>
+    [Output]
+    public string ChangeReason { get; set; }
+
+    /// <summary>
+    /// Output parameter for the discovered Git repository root path
+    /// </summary>
+    [Output]
+    public string DiscoveredRepoRoot { get; set; }
+
+    /// <summary>
+    /// Output parameter for the tag or commit that was compared against
+    /// </summary>
+    [Output]
+    public string ComparedAgainst { get; set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            // Validate required properties
+            if (string.IsNullOrEmpty(ProjectPath))
+                throw new InvalidOperationException("ProjectPath is required but was not provided.");
+
+            // Use project directory as starting point if RepoRoot is not specified
+            var searchStartPath = string.IsNullOrEmpty(RepoRoot)
+                ? Path.GetDirectoryName(ProjectPath)
+                : RepoRoot;
+
+            Log.LogMessage(MessageImportance.High, $"[HasChanges] Checking for changes in {ProjectPath}");
+
+            // Create logger function for core services
+            var logger = MSBuildLoggerFactory.CreateMSBuildLogger(Log, Debug, false);
+
+            // Discover Git repository root
+            var gitRepoRoot = RepositoryService.DiscoverRepository(searchStartPath, logger, "search start path");
+            if (gitRepoRoot == null)
+            {
+                Log.LogError(string.Format(RepositoryService.NoRepositoryFoundError, searchStartPath));
+                Log.LogError(RepositoryService.EnsureGitRepositoryMessage);
+                return false;
+            }
+
+            DiscoveredRepoRoot = gitRepoRoot;
+
+            // Create change detection service
+            using var changeDetectionService = new HasChangesService(gitRepoRoot, logger);
+
+            // Prepare request
+            var dependencies = Dependencies?.Select(d => d.ItemSpec).ToList() ?? new List<string>();
+            var request = new HasChangesRequest
+            {
+                ProjectPath = ProjectPath,
+                RepoRoot = gitRepoRoot,
+                Dependencies = dependencies,
+                TagPrefix = TagPrefix,
+                SinceTag = SinceTag,
+                SinceCommit = SinceCommit,
+                ChangeDetectionEnabled = ChangeDetectionEnabled,
+                IgnorePatterns = ParsePatternString(IgnoreFilePatterns),
+                MajorPatterns = ParsePatternString(MajorFilePatterns),
+                MinorPatterns = ParsePatternString(MinorFilePatterns),
+                PatchPatterns = ParsePatternString(PatchFilePatterns),
+                AdditionalMonitorPaths = ParsePatternString(AdditionalMonitorPaths),
+                Debug = Debug
+            };
+
+            // Execute change detection
+            var result = changeDetectionService.DetectChanges(request);
+
+            // Set output parameters
+            HasChanges = result.HasChanges;
+            ChangeType = result.ChangeType.ToString();
+            ChangeReason = result.Reason;
+            ComparedAgainst = result.ComparedAgainst;
+
+            // Convert changed files to task items
+            if (result.ChangedFiles != null && result.ChangedFiles.Count > 0)
+            {
+                ChangedFiles = result.ChangedFiles
+                    .Select(f => new TaskItem(f) as ITaskItem)
+                    .ToArray();
+            }
+            else
+            {
+                ChangedFiles = Array.Empty<ITaskItem>();
+            }
+
+            // Log results
+            if (HasChanges)
+            {
+                Log.LogMessage(MessageImportance.High,
+                    $"[HasChanges] Changes detected: {ChangeType} - {ChangeReason}");
+                if (Debug && ChangedFiles.Length > 0)
+                {
+                    Log.LogMessage(MessageImportance.High,
+                        $"[HasChanges] Changed files: {string.Join(", ", ChangedFiles.Take(10).Select(f => f.ItemSpec))}");
+                    if (ChangedFiles.Length > 10)
+                    {
+                        Log.LogMessage(MessageImportance.High,
+                            $"[HasChanges] ... and {ChangedFiles.Length - 10} more files");
+                    }
+                }
+            }
+            else
+            {
+                Log.LogMessage(MessageImportance.High,
+                    $"[HasChanges] No changes detected since {ComparedAgainst}");
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, true);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses a semicolon-separated string into a list of patterns
+    /// </summary>
+    private static List<string> ParsePatternString(string patternsString)
+    {
+        if (string.IsNullOrWhiteSpace(patternsString))
+        {
+            return new List<string>();
+        }
+
+        return patternsString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(p => p.Trim())
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToList();
+    }
+}

--- a/Mister.Version/build/Mister.Version.targets
+++ b/Mister.Version/build/Mister.Version.targets
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- Include the versioning task -->
 	<UsingTask TaskName="Mister.Version.MonoRepoVersionTask" AssemblyFile="$(MSBuildThisFileDirectory)../tasks/$(AppSettingStronglyTyped_TFM)/Mister.Version.dll" />
+	<UsingTask TaskName="Mister.Version.HasChangesTask" AssemblyFile="$(MSBuildThisFileDirectory)../tasks/$(AppSettingStronglyTyped_TFM)/Mister.Version.dll" />
 
 	<!-- CRITICAL: Ensure test projects have versions set immediately to prevent GenerateDepsFile errors -->
 	<PropertyGroup Condition="'$(IsTestProject)' == 'true'">
@@ -461,5 +462,62 @@
 		Experimental: Fallback to ensure AssemblyVersion is set
 	</Target>
 	-->
+
+	<!-- ============================================================
+	     HasChanges Task - Lightweight change detection
+	     ============================================================ -->
+
+	<!-- Target to check if a project has changes since the last version tag -->
+	<Target Name="_MonoRepoHasChanges"
+	        Condition="'$(MonoRepoVersioningEnabled)'=='true'">
+		<!-- Automatically detect dependencies based on ProjectReference -->
+		<ItemGroup>
+			<_MonoRepoDependencies Include="@(ProjectReference)" />
+		</ItemGroup>
+
+		<!-- Run the HasChanges task -->
+		<HasChangesTask
+			ProjectPath="$(MSBuildProjectFullPath)"
+			RepoRoot="$(MonoRepoRoot)"
+			TagPrefix="$(MonoRepoTagPrefix)"
+			SinceTag="$(MonoRepoSinceTag)"
+			SinceCommit="$(MonoRepoSinceCommit)"
+			ChangeDetectionEnabled="$(MonoRepoChangeDetectionEnabled)"
+			IgnoreFilePatterns="$(MonoRepoIgnoreFilePatterns)"
+			MajorFilePatterns="$(MonoRepoMajorFilePatterns)"
+			MinorFilePatterns="$(MonoRepoMinorFilePatterns)"
+			PatchFilePatterns="$(MonoRepoPatchFilePatterns)"
+			AdditionalMonitorPaths="$(MonoRepoAdditionalMonitorPaths)"
+			Debug="$(MonoRepoDebug)"
+			Dependencies="@(_MonoRepoDependencies)">
+			<Output TaskParameter="HasChanges" PropertyName="MonoRepoHasChanges" />
+			<Output TaskParameter="ChangeType" PropertyName="MonoRepoChangeType" />
+			<Output TaskParameter="ChangeReason" PropertyName="MonoRepoChangeReason" />
+			<Output TaskParameter="ChangedFiles" ItemName="MonoRepoChangedFiles" />
+			<Output TaskParameter="ComparedAgainst" PropertyName="MonoRepoComparedAgainst" />
+			<Output TaskParameter="DiscoveredRepoRoot" PropertyName="DiscoveredRepoRoot" />
+		</HasChangesTask>
+
+		<Message Text="[MrVersion] HasChanges: $(MonoRepoHasChanges), Type: $(MonoRepoChangeType), Compared Against: $(MonoRepoComparedAgainst)" Importance="High" Condition="'$(MonoRepoDebug)'=='true'" />
+	</Target>
+
+	<!-- Convenience target that can be called explicitly to check for changes -->
+	<Target Name="CheckForChanges" DependsOnTargets="_MonoRepoHasChanges">
+		<Message Text="Project has changes: $(MonoRepoHasChanges)" Importance="High" />
+		<Message Text="Change type: $(MonoRepoChangeType)" Importance="High" Condition="'$(MonoRepoHasChanges)' == 'true'" />
+		<Message Text="Reason: $(MonoRepoChangeReason)" Importance="High" />
+		<Message Text="Compared against: $(MonoRepoComparedAgainst)" Importance="High" />
+	</Target>
+
+	<!-- Target for conditional build based on changes -->
+	<Target Name="_MonoRepoConditionalBuild"
+	        DependsOnTargets="_MonoRepoHasChanges"
+	        Condition="'$(MonoRepoSkipUnchanged)' == 'true'">
+		<!-- Set a property to skip build if no changes -->
+		<PropertyGroup Condition="'$(MonoRepoHasChanges)' == 'false'">
+			<_MonoRepoShouldSkipBuild>true</_MonoRepoShouldSkipBuild>
+		</PropertyGroup>
+		<Message Text="[MrVersion] Project has no changes since $(MonoRepoComparedAgainst) - build may be skipped" Importance="High" Condition="'$(_MonoRepoShouldSkipBuild)' == 'true'" />
+	</Target>
 
 </Project>


### PR DESCRIPTION
Adds a new HasChangesTask that provides a lightweight alternative to MonoRepoVersionTask when you only need to check if a project has changes without calculating a full version.

Features:
- Detect changes since a specific tag, commit, or auto-detect latest tag
- Support for dependency change detection
- File pattern classification (major/minor/patch/ignore)
- Returns changed files list and change type
- Integrates with existing change detection infrastructure

New files:
- HasChangesTask.cs: MSBuild task with inputs/outputs
- HasChangesService.cs: Core service for change detection logic
- HasChangesTaskTests.cs: Unit tests for the new task

MSBuild targets added:
- _MonoRepoHasChanges: Internal target for change detection
- CheckForChanges: Convenience target for explicit change checking
- _MonoRepoConditionalBuild: Optional target for conditional builds
