### PR TITLE
test: add regression tests to verify NuGet dependency versions don't default to 1.0.0

### DIFF
--- a/Mister.Version.Tests/NuGetPackageTests.cs
+++ b/Mister.Version.Tests/NuGetPackageTests.cs
@@ -174,29 +174,322 @@ namespace Mister.Version.Tests
             var monorepoDir = Path.Combine(_testDirectory, "mr-version-test");
             Directory.CreateDirectory(monorepoDir);
             InitializeGitRepo(monorepoDir);
-            
+
             var projectDir = CreateMonorepoProject(monorepoDir, "MyProject", null); // No hardcoded version
-            
+
             // Create initial commit and tag
             GitCommit(monorepoDir, "Initial commit");
             GitTag(monorepoDir, "v1.0.0");
-            
+
             // Make a change
             File.AppendAllText(Path.Combine(projectDir, "Program.cs"), "// Updated");
             GitCommit(monorepoDir, "Update project");
-            
+
             // Act - Use mr-version to calculate version
             var calculatedVersion = GetCalculatedVersion(monorepoDir, projectDir);
-            
+
             // Build and pack with calculated version
             var packagePath = BuildAndPackProject(projectDir, calculatedVersion);
-            
+
             // Assert
             Assert.Equal("1.0.1", calculatedVersion);
-            
+
             var packageVersion = ExtractVersionFromPackage(packagePath);
             Assert.Equal("1.0.1", packageVersion);
         }
+
+        #region Regression Tests - Dependency Version Must Not Default to 1.0.0
+
+        /// <summary>
+        /// Regression test: Ensures project reference dependencies use the calculated version,
+        /// not the default 1.0.0. This was a bug where dependency versions would incorrectly
+        /// fall back to 1.0.0 instead of using the actual project version.
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_DependencyVersion_MustNotBe100_WhenProjectHasDifferentVersion()
+        {
+            // Arrange
+            var testDir = Path.Combine(_testDirectory, "regression-100");
+            Directory.CreateDirectory(testDir);
+
+            // Create dependency project with version 2.5.0 (NOT 1.0.0)
+            var dependencyDir = CreateTestProject("MyDependency", "2.5.0", testDir);
+
+            // Create consumer project that references the dependency
+            var consumerDir = CreateTestProject("MyConsumer", "1.0.0", testDir);
+            AddProjectReference(consumerDir, dependencyDir, "MyDependency");
+
+            // Act
+            BuildProject(dependencyDir);
+            var packagePath = BuildAndPackProject(consumerDir);
+
+            // Assert
+            var dependencies = ExtractDependenciesFromPackage(packagePath);
+            var myDependency = dependencies.FirstOrDefault(d => d.Id == "MyDependency");
+
+            Assert.NotNull(myDependency);
+            Assert.NotEqual("1.0.0", myDependency.Version); // MUST NOT be 1.0.0
+            Assert.Equal("2.5.0", myDependency.Version);    // MUST be the actual version
+        }
+
+        /// <summary>
+        /// Regression test: Verifies that multiple project references all have their
+        /// correct calculated versions, not defaulting to 1.0.0.
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_MultipleDependencies_NoneDefaultTo100()
+        {
+            // Arrange
+            var testDir = Path.Combine(_testDirectory, "multi-dep-regression");
+            Directory.CreateDirectory(testDir);
+
+            // Create multiple dependency projects with different versions
+            var dep1Dir = CreateTestProject("DepOne", "3.2.1", testDir);
+            var dep2Dir = CreateTestProject("DepTwo", "4.0.0", testDir);
+            var dep3Dir = CreateTestProject("DepThree", "2.1.0", testDir);
+
+            // Create consumer that references all three
+            var consumerDir = CreateTestProject("Consumer", "1.0.0", testDir);
+            AddProjectReference(consumerDir, dep1Dir, "DepOne");
+            AddProjectReference(consumerDir, dep2Dir, "DepTwo");
+            AddProjectReference(consumerDir, dep3Dir, "DepThree");
+
+            // Act
+            BuildProject(dep1Dir);
+            BuildProject(dep2Dir);
+            BuildProject(dep3Dir);
+            var packagePath = BuildAndPackProject(consumerDir);
+
+            // Assert
+            var dependencies = ExtractDependenciesFromPackage(packagePath);
+
+            // Verify NONE of the dependencies defaulted to 1.0.0
+            foreach (var dep in dependencies)
+            {
+                Assert.NotEqual("1.0.0", dep.Version);
+            }
+
+            // Verify each has the correct version
+            Assert.Contains(dependencies, d => d.Id == "DepOne" && d.Version == "3.2.1");
+            Assert.Contains(dependencies, d => d.Id == "DepTwo" && d.Version == "4.0.0");
+            Assert.Contains(dependencies, d => d.Id == "DepThree" && d.Version == "2.1.0");
+        }
+
+        /// <summary>
+        /// Regression test: Ensures transitive dependency chain versions are correct
+        /// and don't fall back to 1.0.0 at any level.
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_TransitiveDependencyChain_VersionsNotDefaultTo100()
+        {
+            // Arrange - Create A -> B -> C dependency chain
+            var testDir = Path.Combine(_testDirectory, "transitive-regression");
+            Directory.CreateDirectory(testDir);
+
+            // C is the innermost dependency (version 5.0.0)
+            var projectCDir = CreateTestProject("ProjectC", "5.0.0", testDir);
+
+            // B depends on C (version 3.0.0)
+            var projectBDir = CreateTestProject("ProjectB", "3.0.0", testDir);
+            AddProjectReference(projectBDir, projectCDir, "ProjectC");
+
+            // A depends on B (version 2.0.0)
+            var projectADir = CreateTestProject("ProjectA", "2.0.0", testDir);
+            AddProjectReference(projectADir, projectBDir, "ProjectB");
+
+            // Act
+            BuildProject(projectCDir);
+            BuildProject(projectBDir);
+            var packageBPath = BuildAndPackProject(projectBDir);
+            var packageAPath = BuildAndPackProject(projectADir);
+
+            // Assert - Check B's package has correct C version
+            var depsB = ExtractDependenciesFromPackage(packageBPath);
+            var depCInB = depsB.FirstOrDefault(d => d.Id == "ProjectC");
+            Assert.NotNull(depCInB);
+            Assert.NotEqual("1.0.0", depCInB.Version);
+            Assert.Equal("5.0.0", depCInB.Version);
+
+            // Assert - Check A's package has correct B version
+            var depsA = ExtractDependenciesFromPackage(packageAPath);
+            var depBInA = depsA.FirstOrDefault(d => d.Id == "ProjectB");
+            Assert.NotNull(depBInA);
+            Assert.NotEqual("1.0.0", depBInA.Version);
+            Assert.Equal("3.0.0", depBInA.Version);
+        }
+
+        /// <summary>
+        /// Regression test: Verifies that prerelease versions are correctly propagated
+        /// to dependencies and don't fall back to 1.0.0.
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_PrereleaseVersion_DependencyNotDefaultTo100()
+        {
+            // Arrange
+            var testDir = Path.Combine(_testDirectory, "prerelease-regression");
+            Directory.CreateDirectory(testDir);
+
+            // Create dependency with prerelease version
+            var dependencyDir = CreateTestProject("PrereleaseLib", "2.0.0-beta.1", testDir);
+
+            // Create consumer
+            var consumerDir = CreateTestProject("PrereleaseConsumer", "1.0.0", testDir);
+            AddProjectReference(consumerDir, dependencyDir, "PrereleaseLib");
+
+            // Act
+            BuildProject(dependencyDir);
+            var packagePath = BuildAndPackProject(consumerDir);
+
+            // Assert
+            var dependencies = ExtractDependenciesFromPackage(packagePath);
+            var prereleaseLib = dependencies.FirstOrDefault(d => d.Id == "PrereleaseLib");
+
+            Assert.NotNull(prereleaseLib);
+            Assert.NotEqual("1.0.0", prereleaseLib.Version);
+            Assert.Equal("2.0.0-beta.1", prereleaseLib.Version);
+        }
+
+        /// <summary>
+        /// Regression test: Verifies version with build metadata is correctly propagated.
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_VersionWithMetadata_DependencyNotDefaultTo100()
+        {
+            // Arrange
+            var testDir = Path.Combine(_testDirectory, "metadata-regression");
+            Directory.CreateDirectory(testDir);
+
+            // Create dependency with version that has metadata
+            // Note: NuGet strips build metadata, but version comparison should still work
+            var dependencyDir = CreateTestProject("MetadataLib", "3.1.4", testDir);
+
+            // Create consumer
+            var consumerDir = CreateTestProject("MetadataConsumer", "1.0.0", testDir);
+            AddProjectReference(consumerDir, dependencyDir, "MetadataLib");
+
+            // Act
+            BuildProject(dependencyDir);
+            var packagePath = BuildAndPackProject(consumerDir);
+
+            // Assert
+            var dependencies = ExtractDependenciesFromPackage(packagePath);
+            var metadataLib = dependencies.FirstOrDefault(d => d.Id == "MetadataLib");
+
+            Assert.NotNull(metadataLib);
+            Assert.NotEqual("1.0.0", metadataLib.Version);
+            Assert.StartsWith("3.1.4", metadataLib.Version);
+        }
+
+        /// <summary>
+        /// Regression test: Ensures that when consumer and dependency have different
+        /// major versions, the dependency version is correctly captured (not 1.0.0).
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_DifferentMajorVersions_DependencyVersionCorrect()
+        {
+            // Arrange
+            var testDir = Path.Combine(_testDirectory, "major-version-regression");
+            Directory.CreateDirectory(testDir);
+
+            // Consumer is v1.x, dependency is v7.x - quite different
+            var dependencyDir = CreateTestProject("MajorLib", "7.3.2", testDir);
+            var consumerDir = CreateTestProject("MajorConsumer", "1.2.0", testDir);
+            AddProjectReference(consumerDir, dependencyDir, "MajorLib");
+
+            // Act
+            BuildProject(dependencyDir);
+            var packagePath = BuildAndPackProject(consumerDir);
+
+            // Assert
+            var dependencies = ExtractDependenciesFromPackage(packagePath);
+            var majorLib = dependencies.FirstOrDefault(d => d.Id == "MajorLib");
+
+            Assert.NotNull(majorLib);
+            Assert.NotEqual("1.0.0", majorLib.Version);
+            Assert.Equal("7.3.2", majorLib.Version);
+        }
+
+        /// <summary>
+        /// Regression test: Verifies zero-based versions (0.x.x) are correctly handled
+        /// and don't get confused with default versions.
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_ZeroMajorVersion_DependencyVersionCorrect()
+        {
+            // Arrange
+            var testDir = Path.Combine(_testDirectory, "zero-version-regression");
+            Directory.CreateDirectory(testDir);
+
+            // Create dependency with 0.x version (common for pre-1.0 packages)
+            var dependencyDir = CreateTestProject("ZeroLib", "0.9.5", testDir);
+            var consumerDir = CreateTestProject("ZeroConsumer", "1.0.0", testDir);
+            AddProjectReference(consumerDir, dependencyDir, "ZeroLib");
+
+            // Act
+            BuildProject(dependencyDir);
+            var packagePath = BuildAndPackProject(consumerDir);
+
+            // Assert
+            var dependencies = ExtractDependenciesFromPackage(packagePath);
+            var zeroLib = dependencies.FirstOrDefault(d => d.Id == "ZeroLib");
+
+            Assert.NotNull(zeroLib);
+            Assert.NotEqual("1.0.0", zeroLib.Version);
+            Assert.Equal("0.9.5", zeroLib.Version);
+        }
+
+        /// <summary>
+        /// Regression test: Comprehensive check that extracts ALL dependency versions
+        /// and verifies none are the problematic 1.0.0 default (unless actually 1.0.0).
+        /// </summary>
+        [Fact]
+        public void NuGetPackage_AllDependencyVersions_MatchProjectVersions()
+        {
+            // Arrange - Create a complex dependency graph
+            var testDir = Path.Combine(_testDirectory, "comprehensive-regression");
+            Directory.CreateDirectory(testDir);
+
+            var expectedVersions = new Dictionary<string, string>
+            {
+                { "LibA", "2.0.0" },
+                { "LibB", "3.5.1" },
+                { "LibC", "4.2.0" },
+                { "LibD", "1.8.3" },  // Note: Not 1.0.0
+            };
+
+            // Create all dependency projects
+            var projectDirs = new Dictionary<string, string>();
+            foreach (var kvp in expectedVersions)
+            {
+                projectDirs[kvp.Key] = CreateTestProject(kvp.Key, kvp.Value, testDir);
+            }
+
+            // Create consumer that depends on all
+            var consumerDir = CreateTestProject("ComprehensiveConsumer", "1.0.0", testDir);
+            foreach (var kvp in projectDirs)
+            {
+                AddProjectReference(consumerDir, kvp.Value, kvp.Key);
+            }
+
+            // Act
+            foreach (var dir in projectDirs.Values)
+            {
+                BuildProject(dir);
+            }
+            var packagePath = BuildAndPackProject(consumerDir);
+
+            // Assert
+            var dependencies = ExtractDependenciesFromPackage(packagePath);
+
+            foreach (var expected in expectedVersions)
+            {
+                var dep = dependencies.FirstOrDefault(d => d.Id == expected.Key);
+                Assert.NotNull(dep);
+                Assert.Equal(expected.Value, dep.Version);
+            }
+        }
+
+        #endregion
 
         #region Helper Methods
 


### PR DESCRIPTION
Add comprehensive regression tests to catch the bug where project reference dependency versions would incorrectly fall back to 1.0.0 instead of using the actual calculated version. Tests verify:

- Single dependency version is correct (not 1.0.0)
- Multiple dependencies all have correct versions
- Transitive dependency chains preserve versions at all levels
- Prerelease versions are correctly propagated
- Different major versions between consumer and dependency
- Zero-based versions (0.x.x) are handled correctly
- Comprehensive multi-dependency scenarios
